### PR TITLE
prevent double minting in badge

### DIFF
--- a/contracts/onlydust/deathnote/core/badge/test_badge.cairo
+++ b/contracts/onlydust/deathnote/core/badge/test_badge.cairo
@@ -54,6 +54,24 @@ func test_badge_can_be_minted{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, 
 end
 
 @view
+func test_minting_twice_always_returns_the_same_token_id{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}():
+    alloc_locals
+
+    fixture.initialize()
+
+    %{ stop_prank = start_prank(ids.REGISTRY) %}
+    let (local tokenId1) = badge.mint(CONTRIBUTOR)
+    let (tokenId2) = badge.mint(CONTRIBUTOR)
+    %{ stop_prank() %}
+
+    assert tokenId1 = tokenId2
+
+    return ()
+end
+
+@view
 func test_badge_cannot_be_minted_by_anyone{
     syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
 }():

--- a/contracts/onlydust/deathnote/core/badge_registry/library.cairo
+++ b/contracts/onlydust/deathnote/core/badge_registry/library.cairo
@@ -63,7 +63,8 @@ namespace badge_registry:
 
     func get_badge_contract{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         ) -> (badge_contract : felt):
-        return badge_contract_.read()
+        let (badge_contract) = badge_contract_.read()
+        return (badge_contract)
     end
 
     func get_user_information{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(

--- a/contracts/onlydust/deathnote/test/libraries/user.cairo
+++ b/contracts/onlydust/deathnote/test/libraries/user.cairo
@@ -1,0 +1,32 @@
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+from onlydust.deathnote.core.badge_registry.library import badge_registry, UserInformation
+
+namespace assert_user_that:
+    func badge_contract_is{user : UserInformation}(expected : felt):
+        let actual = user.badge_contract
+        with_attr error_message(
+                "Invalid user badge contract: expected {expected}, actual {actual}"):
+            assert expected = actual
+        end
+        return ()
+    end
+
+    func token_id_is{user : UserInformation}(expected : Uint256):
+        let actual = user.token_id
+        with_attr error_message("Invalid user token id: expected {expected}, actual {actual}"):
+            assert expected = actual
+        end
+        return ()
+    end
+
+    func github_handle_is{user : UserInformation}(expected : felt):
+        let actual = user.handles.github
+        with_attr error_message("Invalid user github handle: expected {expected}, actual {actual}"):
+            assert expected = actual
+        end
+        return ()
+    end
+end

--- a/protostar.toml
+++ b/protostar.toml
@@ -1,5 +1,5 @@
 ["protostar.config"]
-protostar_version = "0.2.1"
+protostar_version = "0.2.3"
 
 ["protostar.project"]
 libs_path = "lib"
@@ -9,7 +9,9 @@ no_color=true
 
 ["protostar.shared_command_configs"]
 cairo_path = ["contracts", "lib/cairo_contracts/src"]
-target="contracts"
+
+["protostar.test"]
+target = ["contracts"]
 
 ["protostar.contracts"]
 badge_registry = [ "./contracts/onlydust/deathnote/core/badge_registry/badge_registry.cairo" ]


### PR DESCRIPTION
closes #8

- :arrow_up: upgrade to protostar 0.2.3
- :bug: prevent double minting
- :recycle: use __setup__ protostar function in e2e tests
