### PR TITLE
open contribution creation, all contributions listing, removed contributor management

### DIFF
--- a/contracts/onlydust/deathnote/core/contributions/contributions.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/contributions.cairo
@@ -17,17 +17,10 @@ end
 # Views
 #
 @view
-func contribution_count{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    contributor_id : Uint256
-) -> (contribution_count : felt):
-    return contributions.contribution_count(contributor_id)
-end
-
-@view
 func contribution{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    contributor_id : Uint256, contribution_id : felt
+    contribution_id : felt
 ) -> (contribution : Contribution):
-    return contributions.contribution(contributor_id, contribution_id)
+    return contributions.contribution(contribution_id)
 end
 
 #
@@ -63,8 +56,8 @@ func revoke_feeder_role{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_
 end
 
 @external
-func add_contribution{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-    contributor_id : Uint256, contribution : Contribution
+func new_contribution{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    contribution : Contribution
 ):
-    return contributions.add_contribution(contributor_id, contribution)
+    return contributions.new_contribution(contribution)
 end

--- a/contracts/onlydust/deathnote/core/contributions/contributions.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/contributions.cairo
@@ -23,6 +23,13 @@ func contribution{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_
     return contributions.contribution(contribution_id)
 end
 
+@view
+func all_contributions{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    contributions_len : felt, contributions : Contribution*
+):
+    return contributions.all_contributions()
+end
+
 #
 # Externals
 #

--- a/contracts/onlydust/deathnote/core/contributions/test_contributions.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/test_contributions.cairo
@@ -16,19 +16,20 @@ func test_new_contribution_can_be_added{
 }():
     fixture.initialize()
 
-    let contribution_id = 123
-    let project_id = 456
+    let contribution1 = Contribution(123, 456, Status.OPEN)
+    let contribution2 = Contribution(124, 456, Status.OPEN)
 
     %{ stop_prank = start_prank(ids.FEEDER) %}
-    contributions.new_contribution(Contribution(contribution_id, project_id, Status.OPEN))
+    contributions.new_contribution(contribution1)
+    contributions.new_contribution(contribution1)  # adding twice the same to test update
+    contributions.new_contribution(contribution2)
     %{ stop_prank() %}
 
-    let (contribution) = contributions.contribution(contribution_id)
-    with contribution:
-        assert_contribution_that.id_is(contribution_id)
-        assert_contribution_that.project_id_is(project_id)
-        assert_contribution_that.status_is(Status.OPEN)
-    end
+    let (count, contribs) = contributions.all_contributions()
+
+    assert 2 = count
+    assert contribution2 = contribs[0]
+    assert contribution1 = contribs[1]
 
     return ()
 end

--- a/contracts/onlydust/deathnote/core/contributions/test_contributions.e2e.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/test_contributions.e2e.cairo
@@ -33,40 +33,16 @@ func test_contributions_e2e{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, ra
     let CONTRIBUTOR_ID = Uint256(12, 0)
 
     with contributions:
-        contributions_access.add_contribution(
-            CONTRIBUTOR_ID, Contribution('onlydust', 'starklings', 23, Status.OPEN)
-        )
-        contributions_access.add_contribution(
-            CONTRIBUTOR_ID, Contribution('onlydust', 'starklings', 24, Status.OPEN)
-        )
-        let (contribution_count) = contributions_access.contribution_count(CONTRIBUTOR_ID)
-        assert contribution_count = 2
+        contributions_access.new_contribution(Contribution(123, 456, Status.OPEN))
+        contributions_access.new_contribution(Contribution(123, 456, Status.OPEN))
 
-        let (contribution) = contributions_access.contribution(CONTRIBUTOR_ID, 0)
+        let (contribution) = contributions_access.contribution(123)
     end
 
     with contribution:
-        assert_contribution_that.repo_owner_is('onlydust')
-        assert_contribution_that.repo_name_is('starklings')
-        assert_contribution_that.pr_id_is(23)
-        assert_contribution_that.pr_status_is(Status.OPEN)
-    end
-
-    with contributions:
-        contributions_access.add_contribution(
-            CONTRIBUTOR_ID, Contribution('onlydust', 'starklings', 23, Status.MERGED)
-        )
-        let (contribution_count) = contributions_access.contribution_count(CONTRIBUTOR_ID)
-        assert contribution_count = 2
-
-        let (contribution) = contributions_access.contribution(CONTRIBUTOR_ID, 0)
-    end
-
-    with contribution:
-        assert_contribution_that.repo_owner_is('onlydust')
-        assert_contribution_that.repo_name_is('starklings')
-        assert_contribution_that.pr_id_is(23)
-        assert_contribution_that.pr_status_is(Status.MERGED)
+        assert_contribution_that.id_is(123)
+        assert_contribution_that.project_id_is(456)
+        assert_contribution_that.status_is(Status.OPEN)
     end
 
     return ()
@@ -82,26 +58,19 @@ namespace contributions_access:
         return (contributions_contract)
     end
 
-    func add_contribution{
+    func new_contribution{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
-    }(contributor_id : Uint256, contribution : Contribution):
+    }(contribution : Contribution):
         %{ stop_prank = start_prank(ids.FEEDER, ids.contributions) %}
-        IContributions.add_contribution(contributions, contributor_id, contribution)
+        IContributions.new_contribution(contributions, contribution)
         %{ stop_prank() %}
         return ()
     end
 
-    func contribution_count{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
-    }(contributor_id : Uint256) -> (contribution_count : felt):
-        let (contribution_count) = IContributions.contribution_count(contributions, contributor_id)
-        return (contribution_count)
-    end
-
     func contribution{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
-    }(contributor_id : Uint256, contribution_id : felt) -> (contribution : Contribution):
-        let (contribution) = IContributions.contribution(contributions, contributor_id, contribution_id)
+    }(contribution_id : felt) -> (contribution : Contribution):
+        let (contribution) = IContributions.contribution(contributions, contribution_id)
         return (contribution)
     end
 end

--- a/contracts/onlydust/deathnote/core/profile/test_profile.cairo
+++ b/contracts/onlydust/deathnote/core/profile/test_profile.cairo
@@ -45,7 +45,8 @@ func test_profile_has_a_name_and_symbol{
 end
 
 @view
-func test_profile_can_be_minted{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
+func test_profile_can_be_minted{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    ):
     alloc_locals
 
     fixture.initialize()
@@ -236,5 +237,4 @@ namespace assert_that:
         end
         return ()
     end
-
 end

--- a/contracts/onlydust/deathnote/core/registry/library.cairo
+++ b/contracts/onlydust/deathnote/core/registry/library.cairo
@@ -35,11 +35,15 @@ end
 # Events
 #
 @event
-func GithubIdentifierRegistered(profile_contract : felt, contributor_id : Uint256, identifier : felt):
+func GithubIdentifierRegistered(
+    profile_contract : felt, contributor_id : Uint256, identifier : felt
+):
 end
 
 @event
-func GithubIdentifierUnregistered(profile_contract : felt, contributor_id : Uint256, identifier : felt):
+func GithubIdentifierUnregistered(
+    profile_contract : felt, contributor_id : Uint256, identifier : felt
+):
 end
 
 #
@@ -217,7 +221,9 @@ namespace internal:
         # Update user with minted token
         let (contributor_id) = IProfile.mint(profile_contract, address)
         let user = UserInformation(
-            profile_contract=profile_contract, contributor_id=contributor_id, identifiers=user.identifiers
+            profile_contract=profile_contract,
+            contributor_id=contributor_id,
+            identifiers=user.identifiers,
         )
 
         return ()

--- a/contracts/onlydust/deathnote/core/registry/test_registry.e2e.cairo
+++ b/contracts/onlydust/deathnote/core/registry/test_registry.e2e.cairo
@@ -75,9 +75,7 @@ namespace registry_access:
         IRegistry.register_github_identifier(registry, contributor, identifier)
         %{ stop_prank() %}
 
-        let (user) = IRegistry.get_user_information_from_github_identifier(
-            registry, identifier
-        )
+        let (user) = IRegistry.get_user_information_from_github_identifier(registry, identifier)
         return (user)
     end
 

--- a/contracts/onlydust/deathnote/interfaces/contributions.cairo
+++ b/contracts/onlydust/deathnote/interfaces/contributions.cairo
@@ -12,6 +12,9 @@ namespace IContributions:
     func contribution(contribution_id : felt) -> (contribution : Contribution):
     end
 
+    func all_contributions() -> (contributions_len : felt, contributions : Contribution*):
+    end
+
     func grant_admin_role(address : felt):
     end
 

--- a/contracts/onlydust/deathnote/interfaces/contributions.cairo
+++ b/contracts/onlydust/deathnote/interfaces/contributions.cairo
@@ -6,13 +6,10 @@ from onlydust.deathnote.core.contributions.library import Contribution
 
 @contract_interface
 namespace IContributions:
-    func contribution_count(contributor_id : Uint256) -> (contribution_count : felt):
+    func new_contribution(contribution : Contribution):
     end
 
-    func contribution(contributor_id : Uint256, contribution_id : felt) -> (contribution : Contribution):
-    end
-
-    func add_contribution(contributor_id : Uint256, contribution : Contribution):
+    func contribution(contribution_id : felt) -> (contribution : Contribution):
     end
 
     func grant_admin_role(address : felt):

--- a/contracts/onlydust/deathnote/test/libraries/contributions.cairo
+++ b/contracts/onlydust/deathnote/test/libraries/contributions.cairo
@@ -3,37 +3,26 @@
 from onlydust.deathnote.core.contributions.library import Contribution
 
 namespace assert_contribution_that:
-    func repo_owner_is{contribution : Contribution}(expected : felt):
-        let actual = contribution.repo_owner
-        with_attr error_message(
-                "Invalid contribution repository owner: expected {expected}, actual {actual}"):
+    func id_is{contribution : Contribution}(expected : felt):
+        let actual = contribution.id
+        with_attr error_message("Invalid contribution ID: expected {expected}, actual {actual}"):
             assert expected = actual
         end
         return ()
     end
 
-    func repo_name_is{contribution : Contribution}(expected : felt):
-        let actual = contribution.repo_name
-        with_attr error_message(
-                "Invalid contribution repository name: expected {expected}, actual {actual}"):
+    func project_id_is{contribution : Contribution}(expected : felt):
+        let actual = contribution.project_id
+        with_attr error_message("Invalid project ID: expected {expected}, actual {actual}"):
             assert expected = actual
         end
         return ()
     end
 
-    func pr_id_is{contribution : Contribution}(expected : felt):
-        let actual = contribution.pr_id
+    func status_is{contribution : Contribution}(expected : felt):
+        let actual = contribution.status
         with_attr error_message(
-                "Invalid contribution pull request id: expected {expected}, actual {actual}"):
-            assert expected = actual
-        end
-        return ()
-    end
-
-    func pr_status_is{contribution : Contribution}(expected : felt):
-        let actual = contribution.pr_status
-        with_attr error_message(
-                "Invalid contribution pull reqyest status: expected {expected}, actual {actual}"):
+                "Invalid contribution status: expected {expected}, actual {actual}"):
             assert expected = actual
         end
         return ()

--- a/contracts/onlydust/deathnote/test/test_e2e.cairo
+++ b/contracts/onlydust/deathnote/test/test_e2e.cairo
@@ -59,16 +59,16 @@ func test_e2e{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
 
     let (contributions) = contributions_access.deployed()
     with contributions:
-        contributions_access.new_contribution(Contribution(123, 456, Status.OPEN))
-        contributions_access.new_contribution(Contribution(124, 456, Status.OPEN))
+        let contribution1 = Contribution(123, 456, Status.OPEN)
+        let contribution2 = Contribution(124, 456, Status.OPEN)
+        contributions_access.new_contribution(contribution1)
+        contributions_access.new_contribution(contribution2)
 
-        let (contribution) = contributions_access.contribution(123)
-    end
+        let (count, contribs) = contributions_access.all_contributions()
 
-    with contribution:
-        assert_contribution_that.id_is(123)
-        assert_contribution_that.project_id_is(456)
-        assert_contribution_that.status_is(Status.OPEN)
+        assert 2 = count
+        assert contribution2 = contribs[0]
+        assert contribution1 = contribs[1]
     end
 
     return ()
@@ -110,6 +110,13 @@ namespace contributions_access:
         IContributions.new_contribution(contributions, contribution)
         %{ stop_prank() %}
         return ()
+    end
+
+    func all_contributions{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
+    }() -> (contribs_len, contribs : Contribution*):
+        let (contribs_len, contribs) = IContributions.all_contributions(contributions)
+        return (contribs_len, contribs)
     end
 
     func contribution{

--- a/contracts/onlydust/deathnote/test/test_e2e.cairo
+++ b/contracts/onlydust/deathnote/test/test_e2e.cairo
@@ -59,23 +59,16 @@ func test_e2e{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
 
     let (contributions) = contributions_access.deployed()
     with contributions:
-        contributions_access.add_contribution(
-            user.contributor_id, Contribution('onlydust', 'starklings', 23, Status.OPEN)
-        )
-        contributions_access.add_contribution(
-            user.contributor_id, Contribution('onlydust', 'starklings', 24, Status.OPEN)
-        )
-        let (contribution_count) = contributions_access.contribution_count(user.contributor_id)
-        assert contribution_count = 2
+        contributions_access.new_contribution(Contribution(123, 456, Status.OPEN))
+        contributions_access.new_contribution(Contribution(124, 456, Status.OPEN))
 
-        let (contribution) = contributions_access.contribution(user.contributor_id, 0)
+        let (contribution) = contributions_access.contribution(123)
     end
 
     with contribution:
-        assert_contribution_that.repo_owner_is('onlydust')
-        assert_contribution_that.repo_name_is('starklings')
-        assert_contribution_that.pr_id_is(23)
-        assert_contribution_that.pr_status_is(Status.OPEN)
+        assert_contribution_that.id_is(123)
+        assert_contribution_that.project_id_is(456)
+        assert_contribution_that.status_is(Status.OPEN)
     end
 
     return ()
@@ -110,26 +103,19 @@ namespace contributions_access:
         return (contributions_contract)
     end
 
-    func add_contribution{
+    func new_contribution{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
-    }(contributor_id : Uint256, contribution : Contribution):
+    }(contribution : Contribution):
         %{ stop_prank = start_prank(ids.FEEDER, ids.contributions) %}
-        IContributions.add_contribution(contributions, contributor_id, contribution)
+        IContributions.new_contribution(contributions, contribution)
         %{ stop_prank() %}
         return ()
     end
 
-    func contribution_count{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
-    }(contributor_id : Uint256) -> (contribution_count : felt):
-        let (contribution_count) = IContributions.contribution_count(contributions, contributor_id)
-        return (contribution_count)
-    end
-
     func contribution{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
-    }(contributor_id : Uint256, contribution_id : felt) -> (contribution : Contribution):
-        let (contribution) = IContributions.contribution(contributions, contributor_id, contribution_id)
+    }(contribution_id : felt) -> (contribution : Contribution):
+        let (contribution) = IContributions.contribution(contributions, contribution_id)
         return (contribution)
     end
 end


### PR DESCRIPTION
- :boom: new contributions (status open and unassigned) admitted only
- :sparkles: add the ability to list all contributions


Removed all contributor management, to be re-implemented with a proper assign/unassign flow
We can now add a contribution with no owner, in OPEN status
We can list all contributions from the smart contract

Next steps:
* assign/unassign contribution with proper state checking
* complete a contribution
* list all open contributions
* list all contributions assigned to a contributor
