### PR TITLE
As a feeder I can assign a contributor to a contribution

### DIFF
--- a/contracts/onlydust/deathnote/core/contributions/contributions.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/contributions.cairo
@@ -68,3 +68,10 @@ func new_contribution{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_ch
 ):
     return contributions.new_contribution(contribution)
 end
+
+@external
+func assign_contributor_to_contribution{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}(contribution_id : felt, contributor_id : Uint256):
+    return contributions.assign_contributor_to_contribution(contribution_id, contributor_id)
+end

--- a/contracts/onlydust/deathnote/core/contributions/library.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/library.cairo
@@ -33,6 +33,7 @@ struct Contribution:
     member id : felt
     member project_id : felt
     member status : felt
+    member contributor_id : Uint256
 end
 
 #
@@ -142,10 +143,9 @@ namespace contributions:
         let (contribution) = contribution_access.read(contribution_id)
         with contribution:
             contribution_access.only_open()
-        end
-
-        let contribution = Contribution(contribution.id, contribution.project_id, Status.ASSIGNED)
-        with contribution:
+            let contribution = Contribution(
+                contribution.id, contribution.project_id, Status.ASSIGNED, contributor_id
+            )
             contribution_access.store()
         end
 
@@ -251,7 +251,7 @@ namespace contribution_access:
         contribution : Contribution,
     }():
         with_attr error_message("Contributions: Contribution is not OPEN"):
-            assert contribution.status = Status.OPEN
+            assert Status.OPEN = contribution.status
         end
         return ()
     end

--- a/contracts/onlydust/deathnote/core/contributions/library.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/library.cairo
@@ -137,6 +137,8 @@ namespace contributions:
     func assign_contributor_to_contribution{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
     }(contribution_id : felt, contributor_id : Uint256):
+        internal.only_feeder()
+
         let (contribution) = contribution_access.read(contribution_id)
         let contribution = Contribution(contribution.id, contribution.project_id, Status.ASSIGNED)
         with contribution:

--- a/contracts/onlydust/deathnote/core/contributions/library.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/library.cairo
@@ -132,6 +132,19 @@ namespace contributions:
         internal.fetch_contribution_loop(contribution_count, contributions)
         return (contributions_len=contribution_count, contributions=contributions)
     end
+
+    # Assign a contributor to a contribution
+    func assign_contributor_to_contribution{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+    }(contribution_id : felt, contributor_id : Uint256):
+        let (contribution) = contribution_access.read(contribution_id)
+        let contribution = Contribution(contribution.id, contribution.project_id, Status.ASSIGNED)
+        with contribution:
+            contribution_access.store()
+        end
+
+        return ()
+    end
 end
 
 namespace internal:

--- a/contracts/onlydust/deathnote/core/contributions/library.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/library.cairo
@@ -107,7 +107,7 @@ namespace contributions:
 
         with contribution:
             contribution_access.assert_valid()
-            contribution_access.only_status(Status.OPEN)
+            contribution_access.only_open()
             contribution_access.store()
         end
 
@@ -140,6 +140,10 @@ namespace contributions:
         internal.only_feeder()
 
         let (contribution) = contribution_access.read(contribution_id)
+        with contribution:
+            contribution_access.only_open()
+        end
+
         let contribution = Contribution(contribution.id, contribution.project_id, Status.ASSIGNED)
         with contribution:
             contribution_access.store()
@@ -240,15 +244,14 @@ namespace contribution_access:
         return ()
     end
 
-    func only_status{
+    func only_open{
         syscall_ptr : felt*,
         pedersen_ptr : HashBuiltin*,
         range_check_ptr,
         contribution : Contribution,
-    }(status : felt):
-        with_attr error_message(
-                "Contributions: Invalid status ({contribution.status}), expected ({status})"):
-            assert status = contribution.status
+    }():
+        with_attr error_message("Contributions: Contribution is not OPEN"):
+            assert contribution.status = Status.OPEN
         end
         return ()
     end

--- a/contracts/onlydust/deathnote/core/contributions/library.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/library.cairo
@@ -270,8 +270,8 @@ namespace contribution_access:
         range_check_ptr,
         contribution : Contribution,
     }():
-        let (existing_contribution) = read(contribution.id)
-        if existing_contribution.id == 0:
+        let (already_exists) = exists(contribution.id)
+        if already_exists == 0:
             let (contribution_count) = contribution_count_.read()
             indexed_contribution_ids_.write(contribution_count, contribution.id)
             contribution_count_.write(contribution_count + 1)
@@ -285,6 +285,18 @@ namespace contribution_access:
         contribution_id : felt
     ) -> (contribution : Contribution):
         let (contribution) = contributions_.read(contribution_id)
+        with_attr error_message("Contributions: Contribution does not exist"):
+            assert_not_zero(contribution.id)
+        end
+
         return (contribution)
+    end
+
+    func exists{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        contribution_id : felt
+    ) -> (exists : felt):
+        let (contribution) = contributions_.read(contribution_id)
+        let (exists) = is_not_zero(contribution.id)
+        return (exists)
     end
 end

--- a/contracts/onlydust/deathnote/core/contributions/test_contributions.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/test_contributions.cairo
@@ -98,6 +98,26 @@ func test_cannot_assign_non_existent_contribution{
 end
 
 @view
+func test_cannot_assign_twice_a_contribution{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}():
+    fixture.initialize()
+
+    const contribution_id = 123
+    let contribution = Contribution(contribution_id, 456, Status.OPEN)
+    let contributor_id = Uint256(1, 0)
+
+    %{ stop_prank = start_prank(ids.FEEDER) %}
+    contributions.new_contribution(contribution)
+    contributions.assign_contributor_to_contribution(contribution_id, contributor_id)
+    %{ expect_revert(error_message="Contributions: Contribution is not OPEN") %}
+    contributions.assign_contributor_to_contribution(contribution_id, contributor_id)
+    %{ stop_prank() %}
+
+    return ()
+end
+
+@view
 func test_contribution_creation_with_invalid_status_is_reverted{
     syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
 }():
@@ -121,7 +141,7 @@ func test_contribution_creation_with_status_not_open_is_reverted{
 
     %{
         stop_prank = start_prank(ids.FEEDER)
-        expect_revert(error_message="Contributions: Invalid status ({contribution.status}), expected (0)")
+        expect_revert(error_message="Contributions: Contribution is not OPEN")
     %}
     contributions.new_contribution(Contribution(123, 456, Status.COMPLETED))
     %{ stop_prank() %}

--- a/contracts/onlydust/deathnote/core/contributions/test_contributions.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/test_contributions.cairo
@@ -58,6 +58,27 @@ func test_feeder_can_assign_contribution_to_contributor{
 end
 
 @view
+func test_anyone_cannot_assign_contribution_to_contributor{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}():
+    fixture.initialize()
+
+    const contribution_id = 123
+    let contribution = Contribution(contribution_id, 456, Status.OPEN)
+    let contributor_id = Uint256(1, 0)
+
+    %{ stop_prank = start_prank(ids.FEEDER) %}
+    contributions.new_contribution(contribution)
+    %{
+        stop_prank() 
+        expect_revert(error_message="Contributions: FEEDER role required")
+    %}
+    contributions.assign_contributor_to_contribution(contribution_id, contributor_id)
+
+    return ()
+end
+
+@view
 func test_contribution_creation_with_invalid_status_is_reverted{
     syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
 }():

--- a/contracts/onlydust/deathnote/core/contributions/test_contributions.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/test_contributions.cairo
@@ -35,6 +35,29 @@ func test_new_contribution_can_be_added{
 end
 
 @view
+func test_feeder_can_assign_contribution_to_contributor{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}():
+    fixture.initialize()
+
+    const contribution_id = 123
+    let contribution = Contribution(contribution_id, 456, Status.OPEN)
+    let contributor_id = Uint256(1, 0)
+
+    %{ stop_prank = start_prank(ids.FEEDER) %}
+    contributions.new_contribution(contribution)
+    contributions.assign_contributor_to_contribution(contribution_id, contributor_id)
+    %{ stop_prank() %}
+
+    let (contribution) = contributions.contribution(contribution_id)
+    with contribution:
+        assert_contribution_that.status_is(Status.ASSIGNED)
+    end
+
+    return ()
+end
+
+@view
 func test_contribution_creation_with_invalid_status_is_reverted{
     syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
 }():

--- a/contracts/onlydust/deathnote/core/contributions/test_contributions.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/test_contributions.cairo
@@ -79,6 +79,25 @@ func test_anyone_cannot_assign_contribution_to_contributor{
 end
 
 @view
+func test_cannot_assign_non_existent_contribution{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}():
+    fixture.initialize()
+
+    const contribution_id = 123
+    let contributor_id = Uint256(1, 0)
+
+    %{
+        stop_prank = start_prank(ids.FEEDER) 
+        expect_revert(error_message="Contributions: Contribution does not exist")
+    %}
+    contributions.assign_contributor_to_contribution(contribution_id, contributor_id)
+    %{ stop_prank() %}
+
+    return ()
+end
+
+@view
 func test_contribution_creation_with_invalid_status_is_reverted{
     syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
 }():

--- a/contracts/onlydust/deathnote/core/contributions/test_contributions.e2e.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/test_contributions.e2e.cairo
@@ -5,7 +5,10 @@ from starkware.cairo.common.uint256 import Uint256
 
 from onlydust.deathnote.interfaces.contributions import IContributions
 from onlydust.deathnote.core.contributions.library import Contribution, Status
-from onlydust.deathnote.test.libraries.contributions import assert_contribution_that
+from onlydust.deathnote.test.libraries.contributions import (
+    assert_contribution_that,
+    contribution_access,
+)
 
 const ADMIN = 'admin'
 const FEEDER = 'feeder'
@@ -33,8 +36,8 @@ func test_contributions_e2e{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, ra
     let CONTRIBUTOR_ID = Uint256(12, 0)
 
     with contributions:
-        contributions_access.new_contribution(Contribution(123, 456, Status.OPEN))
-        contributions_access.new_contribution(Contribution(124, 456, Status.OPEN))
+        contributions_access.new_contribution(123, 456)
+        contributions_access.new_contribution(124, 456)
 
         contributions_access.assign_contributor_to_contribution(123, CONTRIBUTOR_ID)
         let (contribs_len, contribs) = contributions_access.all_contributions()
@@ -54,6 +57,7 @@ func test_contributions_e2e{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, ra
         assert_contribution_that.id_is(123)
         assert_contribution_that.project_id_is(456)
         assert_contribution_that.status_is(Status.ASSIGNED)
+        assert_contribution_that.contributor_is(CONTRIBUTOR_ID)
     end
 
     return ()
@@ -71,8 +75,9 @@ namespace contributions_access:
 
     func new_contribution{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
-    }(contribution : Contribution):
+    }(contribution_id : felt, project_id : felt):
         %{ stop_prank = start_prank(ids.FEEDER, ids.contributions) %}
+        let (contribution) = contribution_access.create(contribution_id, project_id)
         IContributions.new_contribution(contributions, contribution)
         %{ stop_prank() %}
         return ()

--- a/contracts/onlydust/deathnote/interfaces/contributions.cairo
+++ b/contracts/onlydust/deathnote/interfaces/contributions.cairo
@@ -15,6 +15,9 @@ namespace IContributions:
     func all_contributions() -> (contributions_len : felt, contributions : Contribution*):
     end
 
+    func assign_contributor_to_contribution(contribution_id : felt, contributor_id : Uint256):
+    end
+
     func grant_admin_role(address : felt):
     end
 

--- a/contracts/onlydust/deathnote/test/libraries/contributions.cairo
+++ b/contracts/onlydust/deathnote/test/libraries/contributions.cairo
@@ -1,6 +1,8 @@
 %lang starknet
 
-from onlydust.deathnote.core.contributions.library import Contribution
+from starkware.cairo.common.uint256 import Uint256
+
+from onlydust.deathnote.core.contributions.library import Contribution, Status
 
 namespace assert_contribution_that:
     func id_is{contribution : Contribution}(expected : felt):
@@ -26,5 +28,19 @@ namespace assert_contribution_that:
             assert expected = actual
         end
         return ()
+    end
+
+    func contributor_is{contribution : Contribution}(expected : Uint256):
+        let actual = contribution.contributor_id
+        with_attr error_message("Invalid contributor: expected {expected}, actual {actual}"):
+            assert expected = actual
+        end
+        return ()
+    end
+end
+
+namespace contribution_access:
+    func create(contribution_id : felt, project_id : felt) -> (contribution : Contribution):
+        return (Contribution(contribution_id, project_id, Status.OPEN, Uint256(0, 0)))
     end
 end

--- a/contracts/onlydust/deathnote/test/test_e2e.cairo
+++ b/contracts/onlydust/deathnote/test/test_e2e.cairo
@@ -64,11 +64,26 @@ func test_e2e{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
         contributions_access.new_contribution(contribution1)
         contributions_access.new_contribution(contribution2)
 
-        let (count, contribs) = contributions_access.all_contributions()
+        let contributor_id = user.contributor_id
+        contributions_access.assign_contributor_to_contribution(123, contributor_id)
 
-        assert 2 = count
-        assert contribution2 = contribs[0]
-        assert contribution1 = contribs[1]
+        let (count, contribs) = contributions_access.all_contributions()
+    end
+
+    assert 2 = count
+
+    let contribution = contribs[0]
+    with contribution:
+        assert_contribution_that.id_is(124)
+        assert_contribution_that.project_id_is(456)
+        assert_contribution_that.status_is(Status.OPEN)
+    end
+
+    let contribution = contribs[1]
+    with contribution:
+        assert_contribution_that.id_is(123)
+        assert_contribution_that.project_id_is(456)
+        assert_contribution_that.status_is(Status.ASSIGNED)
     end
 
     return ()
@@ -124,5 +139,16 @@ namespace contributions_access:
     }(contribution_id : felt) -> (contribution : Contribution):
         let (contribution) = IContributions.contribution(contributions, contribution_id)
         return (contribution)
+    end
+
+    func assign_contributor_to_contribution{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
+    }(contribution_id : felt, contributor_id : Uint256):
+        %{ stop_prank = start_prank(ids.FEEDER, ids.contributions) %}
+        IContributions.assign_contributor_to_contribution(
+            contributions, contribution_id, contributor_id
+        )
+        %{ stop_prank() %}
+        return ()
     end
 end

--- a/contracts/onlydust/deathnote/test/test_e2e.cairo
+++ b/contracts/onlydust/deathnote/test/test_e2e.cairo
@@ -8,7 +8,10 @@ from onlydust.deathnote.interfaces.contributions import IContributions
 from onlydust.deathnote.interfaces.profile import IProfile
 from onlydust.deathnote.core.contributions.library import Contribution, Status
 from onlydust.deathnote.test.libraries.user import assert_user_that
-from onlydust.deathnote.test.libraries.contributions import assert_contribution_that
+from onlydust.deathnote.test.libraries.contributions import (
+    assert_contribution_that,
+    contribution_access,
+)
 
 const ADMIN = 'onlydust'
 const FEEDER = 'feeder'
@@ -59,10 +62,8 @@ func test_e2e{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
 
     let (contributions) = contributions_access.deployed()
     with contributions:
-        let contribution1 = Contribution(123, 456, Status.OPEN)
-        let contribution2 = Contribution(124, 456, Status.OPEN)
-        contributions_access.new_contribution(contribution1)
-        contributions_access.new_contribution(contribution2)
+        contributions_access.new_contribution(123, 456)
+        contributions_access.new_contribution(124, 456)
 
         let contributor_id = user.contributor_id
         contributions_access.assign_contributor_to_contribution(123, contributor_id)
@@ -84,6 +85,7 @@ func test_e2e{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
         assert_contribution_that.id_is(123)
         assert_contribution_that.project_id_is(456)
         assert_contribution_that.status_is(Status.ASSIGNED)
+        assert_contribution_that.contributor_is(contributor_id)
     end
 
     return ()
@@ -120,8 +122,9 @@ namespace contributions_access:
 
     func new_contribution{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
-    }(contribution : Contribution):
+    }(contribution_id : felt, project_id : felt):
         %{ stop_prank = start_prank(ids.FEEDER, ids.contributions) %}
+        let (contribution) = contribution_access.create(contribution_id, project_id)
         IContributions.new_contribution(contributions, contribution)
         %{ stop_prank() %}
         return ()


### PR DESCRIPTION
closes #34

- :sparkles: can assign a contributor to a contribution
- :sparkles: restrict contribution assignment to FEEDER role
- :sparkles: cannot assign non existing contribution
- :sparkles: prevent double assignment of a given contribution
- :sparkles: store the contributor_id inside the contribution struct
