### PR TITLE
As feeder I can unassign a contribution from a contributor

### DIFF
--- a/contracts/onlydust/deathnote/core/contributions/contributions.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/contributions.cairo
@@ -75,3 +75,10 @@ func assign_contributor_to_contribution{
 }(contribution_id : felt, contributor_id : Uint256):
     return contributions.assign_contributor_to_contribution(contribution_id, contributor_id)
 end
+
+@external
+func unassign_contributor_from_contribution{
+    syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+}(contribution_id : felt):
+    return contributions.unassign_contributor_from_contribution(contribution_id)
+end

--- a/contracts/onlydust/deathnote/core/contributions/library.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/library.cairo
@@ -143,18 +143,30 @@ namespace contributions:
         let (contribution) = contribution_access.read(contribution_id)
         with contribution:
             contribution_access.only_open()
-<<<<<<< HEAD
             let contribution = Contribution(
                 contribution.id, contribution.project_id, Status.ASSIGNED, contributor_id
             )
-=======
+            contribution_access.store()
+        end
+
+        return ()
+    end
+
+    # Unassign a contributor from a contribution
+    func unassign_contributor_from_contribution{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr
+    }(contribution_id : felt):
+        internal.only_feeder()
+
+        let (contribution) = contribution_access.read(contribution_id)
+        with contribution:
+            contribution_access.only_assigned()
         end
 
         let contribution = Contribution(
-            contribution.id, contribution.project_id, Status.ASSIGNED, contributor_id
+            contribution.id, contribution.project_id, Status.OPEN, Uint256(0, 0)
         )
         with contribution:
->>>>>>> d20543b (:sparkles: store the contributor_id inside the contribution struct)
             contribution_access.store()
         end
 
@@ -261,6 +273,18 @@ namespace contribution_access:
     }():
         with_attr error_message("Contributions: Contribution is not OPEN"):
             assert Status.OPEN = contribution.status
+        end
+        return ()
+    end
+
+    func only_assigned{
+        syscall_ptr : felt*,
+        pedersen_ptr : HashBuiltin*,
+        range_check_ptr,
+        contribution : Contribution,
+    }():
+        with_attr error_message("Contributions: Contribution is not ASSIGNED"):
+            assert Status.ASSIGNED = contribution.status
         end
         return ()
     end

--- a/contracts/onlydust/deathnote/core/contributions/library.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/library.cairo
@@ -143,9 +143,18 @@ namespace contributions:
         let (contribution) = contribution_access.read(contribution_id)
         with contribution:
             contribution_access.only_open()
+<<<<<<< HEAD
             let contribution = Contribution(
                 contribution.id, contribution.project_id, Status.ASSIGNED, contributor_id
             )
+=======
+        end
+
+        let contribution = Contribution(
+            contribution.id, contribution.project_id, Status.ASSIGNED, contributor_id
+        )
+        with contribution:
+>>>>>>> d20543b (:sparkles: store the contributor_id inside the contribution struct)
             contribution_access.store()
         end
 

--- a/contracts/onlydust/deathnote/core/contributions/test_contributions.e2e.cairo
+++ b/contracts/onlydust/deathnote/core/contributions/test_contributions.e2e.cairo
@@ -40,6 +40,10 @@ func test_contributions_e2e{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, ra
         contributions_access.new_contribution(124, 456)
 
         contributions_access.assign_contributor_to_contribution(123, CONTRIBUTOR_ID)
+
+        contributions_access.assign_contributor_to_contribution(124, CONTRIBUTOR_ID)
+        contributions_access.unassign_contributor_from_contribution(124)
+
         let (contribs_len, contribs) = contributions_access.all_contributions()
     end
 
@@ -90,6 +94,15 @@ namespace contributions_access:
         IContributions.assign_contributor_to_contribution(
             contributions, contribution_id, contributor_id
         )
+        %{ stop_prank() %}
+        return ()
+    end
+
+    func unassign_contributor_from_contribution{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
+    }(contribution_id : felt):
+        %{ stop_prank = start_prank(ids.FEEDER, ids.contributions) %}
+        IContributions.unassign_contributor_from_contribution(contributions, contribution_id)
         %{ stop_prank() %}
         return ()
     end

--- a/contracts/onlydust/deathnote/interfaces/contributions.cairo
+++ b/contracts/onlydust/deathnote/interfaces/contributions.cairo
@@ -18,6 +18,9 @@ namespace IContributions:
     func assign_contributor_to_contribution(contribution_id : felt, contributor_id : Uint256):
     end
 
+    func unassign_contributor_from_contribution(contribution_id : felt):
+    end
+
     func grant_admin_role(address : felt):
     end
 

--- a/contracts/onlydust/deathnote/test/test_e2e.cairo
+++ b/contracts/onlydust/deathnote/test/test_e2e.cairo
@@ -68,6 +68,9 @@ func test_e2e{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
         let contributor_id = user.contributor_id
         contributions_access.assign_contributor_to_contribution(123, contributor_id)
 
+        contributions_access.assign_contributor_to_contribution(124, contributor_id)
+        contributions_access.unassign_contributor_from_contribution(124)
+
         let (count, contribs) = contributions_access.all_contributions()
     end
 
@@ -151,6 +154,15 @@ namespace contributions_access:
         IContributions.assign_contributor_to_contribution(
             contributions, contribution_id, contributor_id
         )
+        %{ stop_prank() %}
+        return ()
+    end
+
+    func unassign_contributor_from_contribution{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr, contributions : felt
+    }(contribution_id : felt):
+        %{ stop_prank = start_prank(ids.FEEDER, ids.contributions) %}
+        IContributions.unassign_contributor_from_contribution(contributions, contribution_id)
         %{ stop_prank() %}
         return ()
     end


### PR DESCRIPTION
closes #35

- :sparkles: store the contributor_id inside the contribution struct
- :sparkles: feeder can unassign a contributor from a contribution
